### PR TITLE
fixed Certifacate Issuer with empty DNs

### DIFF
--- a/create-self-signed-certs.sh
+++ b/create-self-signed-certs.sh
@@ -60,7 +60,7 @@ openssl req \
   -days 120 \
   -nodes \
   -x509 \
-  -subj "//C=UE\ST=UE\L=UE\O=OCARIoT CA\CN=ocariot.com" \
+  -subj "/C=UE/ST=UE/L=UE/O=OCARIoT CA/CN=ocariot.com" \
   -keyout "${DIR}/ca.key" \
   -out "${DIR}/ca.crt"
 # For each server/service you want to secure with your CA, repeat the


### PR DESCRIPTION
When generating certificates the Issuer ended up with empty DNs which is not allowed in x509 certificates in java.
This change allows to use the certificates to be used in a java key store.
